### PR TITLE
Added mongoose sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 ## installation <a name="id1"></a>
 
 ```
-npm install auto-increment-mongoose
+npm install auto-increment-group
 ```
 
 ## Getting Started <a name="id2"></a>
 
 ```javascript
 import mongoose from 'mongoose';
-import { autoInc } from 'auto-increment-mongoose';
+import { autoInc } from 'auto-increment-group';
 
 const schema = new mongoose.Schema({
     serialNumber: {
@@ -69,7 +69,7 @@ await document2_1.save() // { serialNumber: "0001", name: 'document2_1', company
 
 ```javascript
 import mongoose from 'mongoose';
-import { autoInc } from 'auto-increment-mongoose';
+import { autoInc } from 'auto-increment-group';
 
 const schema = new mongoose.Schema({
     serialNumber: {

--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ await Document.nextCount({
     floor: '1'
 });
 
-await Document.nextCount(null, );
-
-
 // A mongoose session may be passed to the static method as a second parameter.
 const session = await mongoose.connection.startSession();
 session.startTransaction();

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ await Document.nextCount({
     company: '1', 
     floor: '1'
 });
+
+await Document.nextCount(null, );
+
+
+// A mongoose session may be passed to the static method as a second parameter.
+const session = await mongoose.connection.startSession();
+session.startTransaction();
+
+await Document.nextCount('1', session);
+await Document.nextCount('2', session);
+await Document.nextCount({
+    company: '1', 
+    floor: '1'
+}, session);
 ```
 
 ### resetCount
@@ -147,5 +161,18 @@ await Document.resetCount({
     company: '1',
     floor: '1'
 });
+
+
+// A mongoose session may be passed as a second parameter.
+const session = await mongoose.connection.startSession();
+session.startTransaction();
+
+
+await Document.resetCount(session);
+await Document.resetCount('1', session);
+await Document.resetCount({
+    company: '1',
+    floor: '1'
+}, session);
 ```
 

--- a/lib/autoInc.js
+++ b/lib/autoInc.js
@@ -1,20 +1,20 @@
 const isDefined = (obj) => {
     return obj !== undefined && obj !== null;
 };
-const getLastCount = async (model, opts, groupByField = {}) => {
+const getLastCount = async (model, opts, groupByField = {}, session) => {
     const initCount = opts.startAt - opts.incrementBy;
     const query = {};
     if (opts?.groupBy) {
         Object.assign(query, groupByField);
     }
-    const last = await model.findOne(query).select(`${opts.field}`).sort({ _id: -1 });
+    const last = await model.findOne(query).select(`${opts.field}`).sort({ _id: -1 }).session(session);
     if (!last) {
         return initCount;
     }
     return Number(last[opts.field] || initCount);
 };
 
-const resetCount = async (model, opts, groupByField = {}) => {
+const resetCount = async (model, opts, groupByField = {}, session) => {
     const query = {};
     if (opts?.groupBy) {
         Object.assign(query, groupByField);
@@ -24,6 +24,7 @@ const resetCount = async (model, opts, groupByField = {}) => {
     return model.findOneAndUpdate(query, {
         $set: set
     }, {
+        session,
         returnDocument: 'after',
         sort: { _id: -1 }
     });
@@ -88,7 +89,7 @@ const autoInc = (schema, pluginOpts = {}) => {
                     groupByField[opts.groupBy] = this[opts.groupBy];
                 }
             }
-            const count = await getLastCount(this.constructor, opts, groupByField);
+            const count = await getLastCount(this.constructor, opts, groupByField, this.$session());
             this[opts.field] = `${count + opts.incrementBy}`.padStart(opts.digits, '0');
         }
         return next();
@@ -110,31 +111,31 @@ const autoInc = (schema, pluginOpts = {}) => {
                 groupByField[opts.groupBy] = this[opts.groupBy];
             }
         }
-        const count = await getLastCount(this.constructor, opts, groupByField);
+        const count = await getLastCount(this.constructor, opts, groupByField, this.$session());
         return `${count + opts.incrementBy}`.padStart(opts.digits, '0');
     });
-    schema.static('nextCount', async function (groupByFieldNext) {
+    schema.static('nextCount', async function (groupByFieldNext, session) {
         const groupByField = {};
         if (opts?.groupBy) {
             if (typeof groupByFieldNext === 'string') {
                 groupByField[opts.groupBy] = groupByFieldNext;
-            } else if (typeof groupByFieldNext === 'object') {
+            } else if (typeof groupByFieldNext === 'object' && groupByFieldNext !== null) {
                 Object.assign(groupByField, groupByFieldNext);
             }
         }
-        const count = await getLastCount(this, opts, groupByField);
+        const count = await getLastCount(this, opts, groupByField, session);
         return `${count + opts.incrementBy}`.padStart(opts.digits, '0');
     });
-    schema.static('resetCount', async function (groupByFieldNext) {
+    schema.static('resetCount', async function (groupByFieldNext, session) {
         const groupByField = {};
         if (opts?.groupBy) {
             if (typeof groupByFieldNext === 'string') {
                 groupByField[opts.groupBy] = groupByFieldNext;
-            } else if (typeof groupByFieldNext === 'object') {
+            } else if (typeof groupByFieldNext === 'object' && groupByFieldNext !== null) {
                 Object.assign(groupByField, groupByFieldNext);
             }
         }
-        return resetCount(this, opts, groupByField);
+        return resetCount(this, opts, groupByField, session);
     });
 };
 


### PR DESCRIPTION
### What is the current behavior?

When saving multiple documents in a session, the incremental field is set equal for all new documents, because the last value is not being searched within the session.

```javascript
await new Document({}).save(); // id 1
await new Document({}).save(); // id 2

const session = await mongoose.connection.startSession();
session.startTransaction();

await new Document({}).save({ session }); // id 3
await new Document({}).save({ session }); // id 3
await new Document({}).save({ session }); // id 3

await Document.nextCount(); // 3
await Document.resetCount(); // Updates document with id 2 to 1 
```

### What is the new behavior?

New documents are now taken into account when saving multiple documents in the same session.

```javascript
await new Document({}).save(); // id 1
await new Document({}).save(); // id 2

const session = await mongoose.connection.startSession();
session.startTransaction();

await new Document({}).save({ session }); // id 3
await new Document({}).save({ session }); // id 4
await new Document({}).save({ session }); // id 5

await Document.nextCount(null, session); // 6
await Document.resetCount(null, session); // Updates document with id 6 to 1 
```